### PR TITLE
expose highlight color

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -254,9 +254,7 @@ class MolWidget(QtSvg.QSvgWidget):
 
     @staticmethod
     def increase_brightness(x: tuple):
-        print(x)
         x = tuple([min([1, max([0, i + 0.2])]) for i in x])
-        print(x)
         return x
 
 

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -254,7 +254,10 @@ class MolWidget(QtSvg.QSvgWidget):
 
     @staticmethod
     def increase_brightness(x: tuple):
-        x = tuple([min([1, max([0, i + 0.2])]) for i in x])
+        if sum([i for i in x]) < 2.1:
+            x = tuple([min([1, max([0, i + 0.2])]) for i in x])
+        else:
+            x = tuple([min([1, max([0, i - 0.2])]) for i in x])
         return x
 
 


### PR DESCRIPTION
`self._drawColor` and `self.colorDict` have been added as attributes to `molViewWidget`

The `colorDict` is a `Dict["name": Tuple(R,G,B)]`
The "default" rdkit color is `(1.0, 0.5, 0.5)` is also set here as default.

Users can assign `colorDict` alternative colors
And by setting the drawColor can change how the molecules are highlighted.

The last selected atom is also highlighted a little brighter (by a fifth to be precise)