### PR TITLE
Support adding R side chains to molecule

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -92,6 +92,15 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
             if self._mol is not None:
                 self._prevmol = copy.deepcopy(self._mol)  # Chem.Mol(self._mol.ToBinary())  # Copy
 
+            # Fix pseudo atoms
+            atom: Chem.Atom
+            for atom in mol.GetAtoms():
+                if atom.GetAtomicNum() == 0:
+                    if not atom.HasProp("dummyLabel") or atom.GetProp("dummyLabel") == "*":
+                        atom.SetProp("dummyLabel", "R")
+                    else:
+                        print(atom.GetPropsAsDict())
+
             # # TODO make this failsafe
             # if self._updatepropertycache:
             #     try:

--- a/rdeditor/ptable.py
+++ b/rdeditor/ptable.py
@@ -123,6 +123,7 @@ ptable = {
 }
 
 symboltoint = {
+    "R": 0,
     "Ac": 89,
     "Ag": 47,
     "Al": 13,

--- a/rdeditor/ptable_widget.py
+++ b/rdeditor/ptable_widget.py
@@ -47,6 +47,15 @@ class PTable(QtWidgets.QWidget):
                     grid.addWidget(button, 9, key - 54)
                 else:
                     grid.addWidget(button, 10, key - 86)
+        self.atomActions["R"] = QtGui.QAction(
+            "R",
+            self,
+            statusTip="Set atomtype to R",
+            triggered=self.atomtypePush,
+            objectName="R",
+            checkable=True,
+        )
+        actionGroup.addAction(self.atomActions["R"])
         # Ensure spacing between main table and actinides/lathanides
         grid.addWidget(QtWidgets.QLabel(""), 8, 1)
 

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -174,6 +174,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.toolMenu.addAction(self.ezAction)
         self.toolMenu.addAction(self.increaseChargeAction)
         self.toolMenu.addAction(self.decreaseChargeAction)
+        self.toolMenu.addAction(self.numberAtom)
 
         self.toolMenu.addSeparator()
         self.toolMenu.addAction(self.cleanCoordinatesAction)
@@ -262,6 +263,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.mainToolBar.addAction(self.ezAction)
         self.mainToolBar.addAction(self.increaseChargeAction)
         self.mainToolBar.addAction(self.decreaseChargeAction)
+        self.mainToolBar.addAction(self.numberAtom)
         self.mainToolBar.addSeparator()
         self.mainToolBar.addAction(self.cleanCoordinatesAction)
         self.mainToolBar.addAction(self.cleanupMolAction)
@@ -281,6 +283,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.sideToolBar.addSeparator()
         self.sideToolBar.addAction(self.templateActions["benzene"])
         self.sideToolBar.addAction(self.templateActions["cyclohexane"])
+        self.sideToolBar.addSeparator()
+        self.sideToolBar.addAction(self.ptable.atomActions["R"])
         self.sideToolBar.addSeparator()
         for action in self.atomActions:
             self.sideToolBar.addAction(action)
@@ -706,6 +710,16 @@ Version: {rdeditor.__version__}
             checkable=True,
         )
         self.actionActionGroup.addAction(self.decreaseChargeAction)
+
+        self.numberAtom = QAction(
+            "A#",
+            self,
+            statusTip="Number Atom",
+            triggered=self.setAction,
+            objectName="Number Atom",
+            checkable=True,
+        )
+        self.actionActionGroup.addAction(self.numberAtom)
         self.addAction.setChecked(True)
 
         # BondTypeActions


### PR DESCRIPTION
Use virtual atoms as markers for side chains. This is useful for producing templates for automated side chain substitution.

TODO: generate an icon that matches the existing theme