### PR TITLE
Improve dev loop by using relative imports

### DIFF
--- a/rdeditor/molEditWidget.py
+++ b/rdeditor/molEditWidget.py
@@ -17,12 +17,12 @@ from rdkit.Geometry.rdGeometry import Point2D, Point3D
 
 # from rdkit.Chem.AllChem import GenerateDepictionMatching3DStructure
 
-from rdeditor.molViewWidget import MolWidget
-from rdeditor.templatehandler import TemplateHandler
+from .molViewWidget import MolWidget
+from .templatehandler import TemplateHandler
 
 # from types import *
 
-from rdeditor.ptable import symboltoint
+from .ptable import symboltoint
 
 debug = True
 

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -16,7 +16,7 @@ from rdkit.Chem import rdDepictor
 from rdkit.Chem.Draw import rdMolDraw2D
 from rdkit.Geometry.rdGeometry import Point2D
 
-from rdeditor.utilities import validate_rgb
+from .utilities import validate_rgb
 
 
 # The Viewer Class

--- a/rdeditor/ptable_widget.py
+++ b/rdeditor/ptable_widget.py
@@ -5,7 +5,7 @@ import logging
 
 from PySide6 import QtGui, QtCore, QtWidgets
 
-from rdeditor.ptable import ptable
+from .ptable import ptable
 
 
 class PTable(QtWidgets.QWidget):

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -14,9 +14,9 @@ from PySide6.QtGui import QDesktopServices, QIcon, QAction, QKeySequence
 import qdarktheme
 
 # Import model
-import rdeditor
-from rdeditor.molEditWidget import MolEditWidget
-from rdeditor.ptable_widget import PTable
+from . import __version__
+from .molEditWidget import MolEditWidget
+from .ptable_widget import PTable
 
 from rdkit import Chem
 import qdarktheme
@@ -406,7 +406,7 @@ class MainWindow(QtWidgets.QMainWindow):
 Based on RDKit! http://www.rdkit.org/\n
 Some icons from http://icons8.com\n
 Source code: https://github.com/EBjerrum/rdeditor\n
-Version: {rdeditor.__version__}
+Version: {__version__}
             """,
         )
 


### PR DESCRIPTION
Using relative imports allows the module to be run without requiring it to be installed. Once this change has been merged it should be as simple as running `python -m rdeditor.rdEditor` from the root folder.