### PR TITLE
Recaculating coordinates breaks rendering of stereo chem

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -314,7 +314,7 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
                 rdMolDraw2D.SetDarkMode(opts)
             if (not self.molecule_sanitizable) and self.unsanitizable_background_colour:
                 opts.setBackgroundColour(self.unsanitizable_background_colour)
-            opts.prepareMolsBeforeDrawing = False
+            opts.prepareMolsBeforeDrawing = True
             opts.addStereoAnnotation = True  # Show R/S and E/Z
             # for tag in chiraltags:
             #     idx = tag[0]


### PR DESCRIPTION
When recalculating coordinates some of the stereo chem is not updated inside the mol. Setting prepareMolsBeforeDrawing seems to fix this.

This fixes issues https://github.com/EBjerrum/rdeditor/issues/24 and https://github.com/EBjerrum/rdeditor/issues/27