### PR TITLE
Set a fixed bond length to reduce jumping when adding atoms

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -310,6 +310,7 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
             # Chiral tags on R/S
             # chiraltags = Chem.FindMolChiralCenters(self._drawmol)
             opts = self.drawer.drawOptions()
+            opts.fixedBondLength = 15.0
             if self._darkmode:
                 rdMolDraw2D.SetDarkMode(opts)
             if (not self.molecule_sanitizable) and self.unsanitizable_background_colour:

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -304,13 +304,18 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
     finishedDrawing = QtCore.Signal(name="finishedDrawing")
 
     def getMolSvg(self):
-        self.drawer = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        height = 300
+        width = 300
+        self.drawer = rdMolDraw2D.MolDraw2DSVG(width, height)
         # TODO, what if self._drawmol doesn't exist?
         if self._drawmol is not None:
             # Chiral tags on R/S
             # chiraltags = Chem.FindMolChiralCenters(self._drawmol)
             opts = self.drawer.drawOptions()
             opts.fixedBondLength = 15.0
+            maxv = Point2D(0.5 * width / opts.scalingFactor, 0.5 * height / opts.scalingFactor)
+            minv = Point2D(-maxv.x, -maxv.y)
+            self.drawer.SetScale(width, height, minv, maxv)
             if self._darkmode:
                 rdMolDraw2D.SetDarkMode(opts)
             if (not self.molecule_sanitizable) and self.unsanitizable_background_colour:

--- a/rdeditor/templatehandler.py
+++ b/rdeditor/templatehandler.py
@@ -160,10 +160,6 @@ class TemplateHandler:
         """Apply to canvas"""
         template = Chem.MolFromSmiles(self.templates[templatelabel]["canvas"], sanitize=False)
 
-        if mol.GetNumAtoms() == 0:
-            point.x = 0.0
-            point.y = 0.0
-
         combined = Chem.rdchem.RWMol(Chem.CombineMols(mol, template))
         # This should only trigger if we have an empty canvas
         if not combined.GetNumConformers():


### PR DESCRIPTION
This reduces jumping when adding atoms by reducing the need to resize the screen. This could be further improved by preventing the renderer from centering the molecule. Centering should already be turned off, there is likely some other setting that needs to be changed.