### PR TITLE
Drawing settings

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -314,7 +314,7 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
                 rdMolDraw2D.SetDarkMode(opts)
             if (not self.molecule_sanitizable) and self.unsanitizable_background_colour:
                 opts.setBackgroundColour(self.unsanitizable_background_colour)
-            opts.prepareMolsBeforeDrawing = False
+            opts.prepareMolsBeforeDrawing = True
             opts.addStereoAnnotation = True  # Show R/S and E/Z
             # for tag in chiraltags:
             #     idx = tag[0]

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -316,6 +316,7 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
                 opts.setBackgroundColour(self.unsanitizable_background_colour)
             opts.prepareMolsBeforeDrawing = False
             opts.addStereoAnnotation = True  # Show R/S and E/Z
+            opts.unspecifiedStereoIsUnknown = True  # Show wiggly bond at undefined stereo centre
             # for tag in chiraltags:
             #     idx = tag[0]
             #     opts.atomLabels[idx] = self._drawmol.GetAtomWithIdx(idx).GetSymbol() + ":" + tag[1]

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -55,6 +55,7 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
             self._moldrawoptions.prepareMolsBeforeDrawing = True
             self._moldrawoptions.addStereoAnnotation = True
             self._moldrawoptions.unspecifiedStereoIsUnknown = False
+            self._moldrawoptions.fixedBondLength = 25
         else:
             self._moldrawoptions = moldrawoptions
 

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -86,14 +86,14 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
         self.draw()
 
     @property
-    def drawOptions(self):
+    def moldrawoptions(self):
         """Returns the current drawing options.
         If settings aremanipulated directly, a drawSettingsChanged signal is not emitted,
         consider using setDrawOption instead."""
         return self._moldrawoptions
 
-    @drawOptions.setter
-    def drawOptions(self, value):
+    @moldrawoptions.setter
+    def moldrawoptions(self, value):
         self._moldrawoptions = value
         self.drawSettingsChanged.emit()
 

--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -21,7 +21,7 @@ from .utilities import validate_rgb
 
 # The Viewer Class
 class MolWidget(QtSvgWidgets.QSvgWidget):
-    def __init__(self, mol=None, parent=None):
+    def __init__(self, mol=None, parent=None, moldrawoptions: rdMolDraw2D.MolDrawOptions = None):
         # Also init the super class
         super(MolWidget, self).__init__(parent)
 
@@ -49,6 +49,15 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
         self._sanitize = False
         self._updatepropertycache = False
 
+        # Draw options
+        if moldrawoptions is None:
+            self._moldrawoptions = rdMolDraw2D.MolDraw2DSVG(300, 300).drawOptions()
+            self._moldrawoptions.prepareMolsBeforeDrawing = True
+            self._moldrawoptions.addStereoAnnotation = True
+            self._moldrawoptions.unspecifiedStereoIsUnknown = False
+        else:
+            self._moldrawoptions = moldrawoptions
+
         # Bind signales to slots for automatic actions
         self.molChanged.connect(self.sanitize_draw)
         self.selectionChanged.connect(self.draw)
@@ -75,6 +84,25 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
     def darkmode(self, value: bool):
         self._darkmode = bool(value)
         self.draw()
+
+    @property
+    def drawOptions(self):
+        """Returns the current drawing options.
+        If settings aremanipulated directly, a drawSettingsChanged signal is not emitted,
+        consider using setDrawOption instead."""
+        return self._moldrawoptions
+
+    @drawOptions.setter
+    def drawOptions(self, value):
+        self._moldrawoptions = value
+        self.drawSettingsChanged.emit()
+
+    def getDrawOption(self, attribute):
+        return getattr(self._moldrawoptions, attribute)
+
+    def setDrawOption(self, attribute, value):
+        setattr(self._moldrawoptions, attribute, value)
+        self.drawSettingsChanged.emit()
 
     # Getter and setter for mol
     molChanged = QtCore.Signal(name="molChanged")
@@ -309,14 +337,15 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
         if self._drawmol is not None:
             # Chiral tags on R/S
             # chiraltags = Chem.FindMolChiralCenters(self._drawmol)
+            self.drawer.SetDrawOptions(self._moldrawoptions)
             opts = self.drawer.drawOptions()
             if self._darkmode:
                 rdMolDraw2D.SetDarkMode(opts)
             if (not self.molecule_sanitizable) and self.unsanitizable_background_colour:
                 opts.setBackgroundColour(self.unsanitizable_background_colour)
-            opts.prepareMolsBeforeDrawing = True
-            opts.addStereoAnnotation = True  # Show R/S and E/Z
-            opts.unspecifiedStereoIsUnknown = True  # Show wiggly bond at undefined stereo centre
+            # opts.prepareMolsBeforeDrawing = True
+            # opts.addStereoAnnotation = True  # Show R/S and E/Z
+            # opts.unspecifiedStereoIsUnknown = True  # Show wiggly bond at undefined stereo centre
             # for tag in chiraltags:
             #     idx = tag[0]
             #     opts.atomLabels[idx] = self._drawmol.GetAtomWithIdx(idx).GetSymbol() + ":" + tag[1]

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -33,16 +33,18 @@ class MainWindow(QtWidgets.QMainWindow):
             [os.path.abspath(os.path.dirname(__file__)) + "/icon_themes/"]
         )
         self.loglevels = ["Critical", "Error", "Warning", "Info", "Debug", "Notset"]
+        # RDKit draw options, tooltip, default value is read from molViewWidget
         self._drawopts_actions = [
             (
                 "prepareMolsBeforeDrawing",
-                True,
                 "Prepare molecules before drawing (i.e. fix stereochemistry and annotations)",
             ),
-            ("addStereoAnnotation", True, "Add stereo annotation (R/S and E/Z)"),
+            (
+                "addStereoAnnotation",
+                "Add stereo annotation (R/S and E/Z)",
+            ),
             (
                 "unspecifiedStereoIsUnknown",
-                False,
                 "Show wiggly bond at potentialundefined chiral stereo centres and cross bonds for undefined doublebonds",
             ),
         ]
@@ -146,6 +148,14 @@ class MainWindow(QtWidgets.QMainWindow):
         kekulize_on_cleanup = self.settings.value("kekulize_on_cleanup", True, type=bool)
         self.editor.kekulize_on_cleanup = kekulize_on_cleanup
         self.cleanupSettingActions["kekulize_on_cleanup"].setChecked(kekulize_on_cleanup)
+
+        # Draw options
+        for key, value, statusTip in self._drawopts_actions:
+            viewer_value = self.editor.getDrawOption(key)
+            settings_value = self.settings.value(f"drawoptions/{key}", viewer_value, type=bool)
+            if settings_value != viewer_value:
+                self.editor.setDrawOption(key, settings_value)
+            self.drawOptionsActions[key].setChecked(settings_value)
 
     # Function to setup status bar, central widget, menu bar, tool bar
     def SetupComponents(self):
@@ -473,6 +483,8 @@ Version: {__version__}
         sender = self.sender()
         option = sender.objectName()
         self.editor.setDrawOption(option, sender.isChecked())
+        self.settings.setValue(f"drawoptions/{option}", sender.isChecked())
+        self.settings.sync()
 
     def setTheme(self):
         sender = self.sender()

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -158,6 +158,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.editor.setDrawOption(key, settings_value)
             self.drawOptionsActions[key].setChecked(settings_value)
 
+        if self.settings.contains("drawoptions/fixedBondLength"):
+            fixedBondLength = self.settings.value("drawoptions/fixedBondLength", 15, type=int)
+            self.editor.setDrawOption("fixedBondLength", fixedBondLength)
+
     # Function to setup status bar, central widget, menu bar, tool bar
     def SetupComponents(self):
         self.myStatusBar = QStatusBar()

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -45,7 +45,8 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
             (
                 "unspecifiedStereoIsUnknown",
-                "Show wiggly bond at potentialundefined chiral stereo centres and cross bonds for undefined doublebonds",
+                "Show wiggly bond at potential undefined chiral stereo centres "
+                + "and cross bonds for undefined doublebonds",
             ),
         ]
 
@@ -150,7 +151,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.cleanupSettingActions["kekulize_on_cleanup"].setChecked(kekulize_on_cleanup)
 
         # Draw options
-        for key, value, statusTip in self._drawopts_actions:
+        for key, statusTip in self._drawopts_actions:
             viewer_value = self.editor.getDrawOption(key)
             settings_value = self.settings.value(f"drawoptions/{key}", viewer_value, type=bool)
             if settings_value != viewer_value:
@@ -243,7 +244,7 @@ class MainWindow(QtWidgets.QMainWindow):
         for key, action in self.cleanupSettingActions.items():
             self.cleanupMenu.addAction(action)
         self.drawOptionsMenu = self.settingsMenu.addMenu("Drawing Options")
-        for key, value, statusTip in self._drawopts_actions:
+        for key, statusTip in self._drawopts_actions:
             self.drawOptionsMenu.addAction(self.drawOptionsActions[key])
 
         # Help menu
@@ -949,7 +950,7 @@ Version: {__version__}
             self.loglevelActionGroup.addAction(self.loglevelactions[key])
 
         self.drawOptionsActions = {}
-        for key, value, statusTip in self._drawopts_actions:
+        for key, statusTip in self._drawopts_actions:
             self.drawOptionsActions[key] = QAction(
                 key, self, statusTip=statusTip, triggered=self.setDrawOption, objectName=key, checkable=True
             )

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -33,6 +33,20 @@ class MainWindow(QtWidgets.QMainWindow):
             [os.path.abspath(os.path.dirname(__file__)) + "/icon_themes/"]
         )
         self.loglevels = ["Critical", "Error", "Warning", "Info", "Debug", "Notset"]
+        self._drawopts_actions = [
+            (
+                "prepareMolsBeforeDrawing",
+                True,
+                "Prepare molecules before drawing (i.e. fix stereochemistry and annotations)",
+            ),
+            ("addStereoAnnotation", True, "Add stereo annotation (R/S and E/Z)"),
+            (
+                "unspecifiedStereoIsUnknown",
+                False,
+                "Show wiggly bond at potentialundefined chiral stereo centres and cross bonds for undefined doublebonds",
+            ),
+        ]
+
         self.editor = MolEditWidget()
         self.chemEntityActionGroup = QtGui.QActionGroup(self, exclusive=True)
         self.ptable = PTable(self.chemEntityActionGroup)
@@ -218,6 +232,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.cleanupMenu = self.settingsMenu.addMenu("Cleanup")
         for key, action in self.cleanupSettingActions.items():
             self.cleanupMenu.addAction(action)
+        self.drawOptionsMenu = self.settingsMenu.addMenu("Drawing Options")
+        for key, value, statusTip in self._drawopts_actions:
+            self.drawOptionsMenu.addAction(self.drawOptionsActions[key])
 
         # Help menu
         self.helpMenu.addAction(self.aboutAction)
@@ -451,6 +468,11 @@ Version: {__version__}
         self.editor.logger.log(self.editor.logger.getEffectiveLevel(), f"loglevel set to {loglevel}")
         self.settings.setValue("loglevel", loglevel)
         self.settings.sync()
+
+    def setDrawOption(self):
+        sender = self.sender()
+        option = sender.objectName()
+        self.editor.setDrawOption(option, sender.isChecked())
 
     def setTheme(self):
         sender = self.sender()
@@ -913,6 +935,13 @@ Version: {__version__}
                 checkable=True,
             )
             self.loglevelActionGroup.addAction(self.loglevelactions[key])
+
+        self.drawOptionsActions = {}
+        for key, value, statusTip in self._drawopts_actions:
+            self.drawOptionsActions[key] = QAction(
+                key, self, statusTip=statusTip, triggered=self.setDrawOption, objectName=key, checkable=True
+            )
+            # self.drawOptionsActionGroup.addAction(self.drawOptionsActions[key])
 
         self.openChemRxiv = QAction(
             QIcon.fromTheme("icons8-Exit"),


### PR DESCRIPTION
Drawing options can now be customized on the molVIewWidget and a few default changes are implemented. These settings has been exposed in the rdEditor and are persistent via QSetting.