### PR TITLE
Fix #38: make canvas size responsive to window resizing

### DIFF
--- a/rdeditor/molViewWidget.py
+++ b/rdeditor/molViewWidget.py
@@ -66,7 +66,9 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
         self.sanitizeSignal.connect(self.changeSanitizeStatus)
 
         # Initialize class with the mol passed
+        self.scale = 1
         self.mol = mol
+        self.setMinimumSize(300, 300)
 
     ##Properties and their wrappers
     @property
@@ -241,6 +243,14 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
         else:
             self.molecule_sanitizable = False
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.draw()
+
+    def setScale(self, scale):
+        self.scale = scale
+        self.draw()
+
     def computeNewCoords(self, ignoreExisting=False, canonOrient=False):
         """Computes new coordinates for the molecule taking into account all
         existing positions (feeding these to the rdkit coordinate generation as
@@ -333,7 +343,8 @@ class MolWidget(QtSvgWidgets.QSvgWidget):
     finishedDrawing = QtCore.Signal(name="finishedDrawing")
 
     def getMolSvg(self):
-        self.drawer = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        width, height = int(self.width() / self.scale), int(self.height() / self.scale)
+        self.drawer = rdMolDraw2D.MolDraw2DSVG(width, height)
         # TODO, what if self._drawmol doesn't exist?
         if self._drawmol is not None:
             # Chiral tags on R/S

--- a/rdeditor/rdEditor.py
+++ b/rdeditor/rdEditor.py
@@ -77,7 +77,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setGeometry(100, 100, 200, 150)
 
         self.center = self.editor
-        self.center.setFixedSize(650, 650)
         self.setCentralWidget(self.center)
         self.fileName = fileName
 
@@ -288,6 +287,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.mainToolBar.addAction(self.openAction)
         self.mainToolBar.addAction(self.saveAction)
         self.mainToolBar.addAction(self.saveAsAction)
+        self.mainToolBar.addSeparator()
+        self.scalewidget = QtWidgets.QComboBox()
+        self.scalewidget.addItems(["75%", "100%", "125%", "150%", "175%", "200%"])
+        self.scalewidget.setCurrentIndex(1)
+        self.scalewidget.currentIndexChanged.connect(lambda: self.editor.setScale(float(self.scalewidget.currentText().strip('%'))/100))
+        self.mainToolBar.addWidget(self.scalewidget)
         self.mainToolBar.addSeparator()
         self.mainToolBar.addAction(self.selectAction)
         self.mainToolBar.addAction(self.addAction)


### PR DESCRIPTION
The rdeditor is a well-designed molecular editor built on PySide6, providing a clean and extensible interface for chemical structure editing. To further improve its usability and adaptability, this pull request introduces a responsive canvas size that automatically adjusts to window resizing. In addition, a QComboBox control for adjusting molecular display size has been added, allowing users to conveniently scale molecular structures during editing. These enhancements provide a more flexible and user-friendly experience and resolve issue #38.